### PR TITLE
Fix server crash by adding required dependency: dataclasses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lxml
 gunicorn
 pybadges
 html.parser
+dataclasses


### PR DESCRIPTION
As mentioned in Issue #17, the server becomes dead since late Jan. I tried to deploy the app on my own and review the logs on vercel side.
![image](https://user-images.githubusercontent.com/54523581/154419970-dd8468e9-2bb1-4ab9-9d92-9000e2176157.png)
 It was due to the dataclasses dependency.

Hence, I added the dataclasses into requirements.txt and that has solved the problem!