### PR TITLE
Changes URI data to beecrowd data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo helps you to create your custom profile badges with Max rating in Code
 Use the package manager [pip3](https://pip.pypa.io/en/stable/) to install requirements file first.
 
 ```bash
-pip3 install requirements.text
+pip3 install -r requirements.text
 ```
 
 ## Endpoints
@@ -28,7 +28,7 @@ https://cp-logo.vercel.app/codechef/<user_name>
 https://cp-logo.vercel.app/atcoder/<user_name>
 https://cp-logo.vercel.app/topcoder/<user_name>
 https://cp-logo.vercel.app/yukicoder/<user_name>
-https://cp-logo.vercel.app/uri/<user_name>
+https://cp-logo.vercel.app/beecrowd/<user_name>
 https://cp-logo.vercel.app/leetcode/<user_name>
 https://cp-logo.vercel.app/leetcode-cn/<user_name>
 ```
@@ -89,9 +89,9 @@ Some examples are -
 ![Badge](https://cp-logo.vercel.app/yukicoder/ganariya)
 ![Badge](https://cp-logo.vercel.app/yukicoder/imulan)
 
-![Badge](https://cp-logo.vercel.app/uri/40926)
-![Badge](https://cp-logo.vercel.app/uri/440377)
-![Badge](https://cp-logo.vercel.app/uri/40980)
+![Badge](https://cp-logo.vercel.app/beecrowd/40926)
+![Badge](https://cp-logo.vercel.app/beecrowd/440377)
+![Badge](https://cp-logo.vercel.app/beecrowd/40980)
 
 ![Badge](https://cp-logo.vercel.app/topcoder/AmAtUrECoDeR)
 ![Badge](https://cp-logo.vercel.app/topcoder/tourist)

--- a/data.py
+++ b/data.py
@@ -17,8 +17,8 @@ def get_info(handle, website):
         return get_top(handle)
     elif website == 'yukicoder':
         return get_yuki(handle)
-    elif website == 'uri':
-        return get_uri(handle)
+    elif website == 'beecrowd':
+        return get_beecrowd(handle)
     elif website == 'leetcode':
         return get_leetcode(handle)
     elif website == 'leetcode-cn':
@@ -141,8 +141,8 @@ def get_yuki(user):
     return [level, color]
 
 
-def get_uri(user_id):
-    url = f'https://www.urionlinejudge.com.br/judge/pt/profile/{user_id}'
+def get_beecrowd(user_id):
+    url = f'https://www.beecrowd.com.br/judge/pt/profile/{user_id}'
     r = requests.get(url).text
 
     soup = bs(r, 'html.parser')

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ logos = {
     'atcoder': 'https://img.atcoder.jp/assets/atcoder.png',
     'topcoder': 'https://raw.githubusercontent.com/donnemartin/interactive-coding-challenges/master/images/logo_topcoder.png',
     'yukicoder': 'https://pbs.twimg.com/profile_images/875757061669232640/T1_mPQuO_400x400.jpg',
-    'uri': 'https://www.urionlinejudge.com.br/judge/img/5.0/logo.130615.png?1591503281',
+    'beecrowd': 'https://www.beecrowd.com.br/judge/img/5.0/logo-beecrowd.png?1635097036',
     'leetcode': 'https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/resources/LeetCode.png',
     'leetcode-cn': 'https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/resources/LeetCode.png'
 }
@@ -23,7 +23,7 @@ website_text = {
     'codeforces': 'Codeforces',
     'topcoder': 'TopCoder',
     'yukicoder': 'YukiCoder',
-    'uri': 'URI',
+    'beecrowd': 'Beecrowd',
     'leetcode': 'LeetCode',
     'leetcode-cn': 'LeetCode-CN'
 }
@@ -43,7 +43,7 @@ def get_badge(handle, website):
     if display_logo:
         if display_link:
             badge = pybadges.badge(left_text=text, right_text=rating,
-                                   right_color=color, logo=logo, embed_logo=True, left_link=link)
+                right_color=color, logo=logo, embed_logo=True, left_link=link)
         else:
             badge = pybadges.badge(
                 left_text=text, right_text=rating, right_color=color, logo=logo, embed_logo=True)


### PR DESCRIPTION
[URI online judge](urionlinejudge.com.br) is now called [Beecrowd](https://www.beecrowd.com.br).
Profile example: https://www.beecrowd.com.br/judge/pt/profile/384586
User ID: 384586

previously: api_url/uri/384586
now: api_url/beecrowd/384586
